### PR TITLE
replace styles css boostrap

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -99,8 +99,8 @@ body {
   }
 }
 
-@media(max-width: 1367px){
-  .button{
+@media(max-width: 1367px) {
+  .button {
     width: 15rem;
   }
 }
@@ -108,9 +108,29 @@ body {
 /***********************Styles Boostrap Changed*******************/
 
 
-.nav-link{
-  font-family:"Texto Thin";
+.nav-link {
+  font-family: "Texto Thin";
 }
-.navbar-toggler-icon{
-  color:var(--primary-color)
+
+.navbar-toggler-icon {
+  color: var(--primary-color)
+}
+
+.navbar-toggler {
+  color: var(--primary-color) !important;
+}
+
+.btn-primary {
+  --bs-btn-bg: #004b82 !important;
+}
+
+.pagination {
+  --bs-pagination-color: #004b82 !important;
+  --bs-pagination-active-bg: #004b82 !important;
+  --bs-pagination-active-border-color: #004b82 !important;
+}
+
+.navbar-toggler-icon {
+  --bs-navbar-toggler-icon-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%28125, 200, 236, 0.55%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
+  background-size: 150%;
 }


### PR DESCRIPTION
* Todos estos cambio son desde nuetra index.css para que reemplacen a los estilos css asignados a esas variables.
* 
- Se cambió el btn primary color original de boostrap por el color que usamos en nuestra web  #004b82 
.btn-primary {
  --bs-btn-bg: #004b82 !important;
}
-  Se cambió el color original de paginatión de boostrap por el color que usamos en nuestra web  #004b82
-  Se cambio el color de tres barritas del navBar Hamburguesa por el color que usamos en nuestra web #7dc8ec

